### PR TITLE
Fix to differentiate the daemon command and interactive command

### DIFF
--- a/src/tarballs/bin.ts
+++ b/src/tarballs/bin.ts
@@ -83,9 +83,13 @@ else
   if [ "\$DEBUG" == "*" ]; then
     echoerr ${binPathEnvVar}="\$${binPathEnvVar}" "\$NODE" "\$DIR/run" "\$@"
   fi
-  "\$NODE" "\$DIR/run" "\$@" &
-  cmd_pid=$!
-  wait $cmd_pid
+  if [ "$1" = "start" ]; then
+    "$NODE" "$DIR/run" "$@" &
+    cmd_pid=$!
+    wait $cmd_pid
+  else
+    "$NODE" "$DIR/run" "$@"
+  fi
 fi
 `)
     await qq.chmod(bin, 0o755)


### PR DESCRIPTION
### Description
- Fix to differentiate "start" command and only "start" command run as daemon
- Other commands run as interactive commands